### PR TITLE
Add '-D' alternate key delimiter option

### DIFF
--- a/lib/jsontool.js
+++ b/lib/jsontool.js
@@ -152,6 +152,7 @@ function printHelp() {
   util.puts("                '-e' and '-c' automatically processing each");
   util.puts("                item of an input array.");
   util.puts("  -d DELIM      Delimiter string for tabular output (default is ' ').");
+  util.puts("  -D DELIM      Delimiter character between lookups (default is '.').");
   util.puts("");
   util.puts("  -e CODE       Execute the given code on the input. If input is an");
   util.puts("                array, then each item of the array is processed");
@@ -196,7 +197,8 @@ function parseArgv(argv) {
     outputMode: OM_JSONY,
     jsonIndent: 2,
     array: null,
-    delim: ' '
+    delim: ' ',
+    lookupDelim: '.'
   };
 
   // Turn '-iH' into '-i -H', except for argument-accepting options.
@@ -275,6 +277,9 @@ function parseArgv(argv) {
       case "-d":
         parsed.delim = _parseString(args.shift());
         break;
+      case "-D":
+        parsed.lookupDelim = args.shift()[0];
+        break;
       case "-e":
         parsed.exeSnippets.push(args.shift());
         break;
@@ -304,7 +309,8 @@ function isInteger(s) {
 // Parse a lookup string into a list of lookup bits. E.g.:
 //    "a.b.c" -> ["a","b","c"]
 //    "b['a']" -> ["b","['a']"]
-function parseLookup(lookup) {
+// Optionally receives an alternative lookup delimiter (other than '.')
+function parseLookup(lookup, lookupDelim) {
   //var debug = console.warn;
   var debug = function () {};
 
@@ -312,6 +318,7 @@ function parseLookup(lookup) {
   debug("\n*** "+lookup+" ***")
 
   bits = [];
+  lookupDelim = lookupDelim || ".";
   var bit = "";
   var states = [null];
   var escaped = false;
@@ -343,7 +350,7 @@ function parseLookup(lookup) {
         }
         bit += ch;
         break;
-      case '.':
+      case lookupDelim:
         if (bit !== "") {
           bits.push(bit);
           bit = ""
@@ -475,7 +482,7 @@ function parseInput(buffer) {
  *
  * @argument datum {Object}
  * @argument lookup {Array} The parsed lookup (from
- *    `parseLookup(<string>)`). Might be empty.
+ *    `parseLookup(<string>, <string>)`). Might be empty.
  * @returns {Object} The result of the lookup.
  */
 function lookupDatum(datum, lookup) {
@@ -768,7 +775,9 @@ function main(argv) {
 
     // Process: lookups
     var lookupsAreIndeces = false;
-    var lookups = lookupStrs.map(parseLookup);
+    var lookups = lookupStrs.map(function(lookup) {
+        return parseLookup(lookup, opts.lookupDelim);
+    });
     if (lookups.length) {
       if (opts.array) {
         if (!Array.isArray(data)) data = [data];

--- a/test/test.js
+++ b/test/test.js
@@ -59,6 +59,11 @@ var data = {
     test.deepEqual(parseLookup("['a\\'[b']"), ["['a\\'[b']"]);
     test.deepEqual(parseLookup("['a\\'[b'].c"), ["['a\\'[b']", "c"]);
 
+    test.deepEqual(parseLookup("a/b", "/"), ["a", "b"]);
+    test.deepEqual(parseLookup("a.b/c", "/"), ["a.b", "c"]);
+    test.deepEqual(parseLookup("a.b/c[42]", "/"), ["a.b", "c", "[42]"]);
+    test.deepEqual(parseLookup('["a/b"]', "/"), ['["a/b"]']);
+
     test.done();
   }
 };


### PR DESCRIPTION
Useful for cases where handing input with lots of dots inside keys:

```
$ cat adotdotb.json
{"a.b": {"b": 1}}
$ cat adotdotb.json | bin/json '["a.b"].b' # ugly
1
$ cat adotdotb.json | bin/json -D / a.b/b  # pretty
1
$
```

What do you think?
