### PR TITLE
Adding `prettyjson` module support to output formats

### DIFF
--- a/lib/jsontool.js
+++ b/lib/jsontool.js
@@ -33,11 +33,13 @@ var OM_JSONY = 1;
 var OM_JSON = 2;
 var OM_INSPECT = 3;
 var OM_COMPACT = 4;
+var OM_PRETTY = 5;
 var OM_FROM_NAME = {
   "jsony": OM_JSONY,
   "json": OM_JSON,
   "inspect": OM_INSPECT,
-  "compact": OM_COMPACT
+  "compact": OM_COMPACT,
+  "pretty": OM_PRETTY
 }
 
 
@@ -206,8 +208,10 @@ function printHelp() {
   util.puts("                  json: JSON output, 2-space indent");
   util.puts("                  json-N: JSON output, N-space indent, e.g. 'json-4'");
   util.puts("                  inspect: node.js `util.inspect` output");
+  util.puts("                  pretty: YAML-like output using the `prettyjson` module");
   util.puts("  -i            shortcut for `-o inspect`");
   util.puts("  -j            shortcut for `-o json`");
+  util.puts("  -p            shortcut for `-o pretty`");
   util.puts("");
   util.puts("See <https://github.com/trentm/json> for more complete docs.");
 }
@@ -308,6 +312,9 @@ function parseArgv(argv) {
         break;
       case "-j": // output with JSON.stringify
         parsed.outputMode = OM_JSON;
+        break;
+      case "-p": // output with prettyjson
+        parsed.outputMode = OM_PRETTY;
         break;
       case "-a":
       case "--array":
@@ -609,6 +616,14 @@ function printDatum(datum, opts, sep, alwaysPrintSep) {
     } else if (typeof datum !== 'undefined') {
       output = JSON.stringify(datum, null, opts.jsonIndent);
     }
+    break;
+  case OM_PRETTY:
+    var options = {
+      keysColor: process.env.JSON_PP_KEY_COLOR,
+      dashColor: process.env.JSON_PP_DASH_COLOR,
+      defaultIndent: process.env.JSON_PP_INDENT
+    };
+    console.log(require('prettyjson').render(datum, options));
     break;
   default:
     throw new Error("unknown output mode: "+opts.outputMode);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   },
   "engines": ["node >=0.4.0"],
   "keywords": ["json", "jsontool", "filter", "command", "shell"],
+  "dependencies": {
+    "prettyjson": "= 0.5.0"
+  },
   "devDependencies": {
     "uglify-js": "1.1.x",
     "nodeunit": "0.7.x",


### PR DESCRIPTION
- Run with `-o pretty` or `-p` to use
- Environmental variables to override colors

Example, i'd recommend trying this yourself to get the full colorful effect

```
$ export JSON_PP_KEY_COLOR=cyan
$ export JSON_PP_DASH_COLOR=black
$ ./bin/json -p < package.json 
name:            jsontool
description:     a 'json' command for massaging JSON on the command line
version:         3.2.1
repository: 
  type: git
  url:  git://github.com/trentm/json.git
author:          Trent Mick <trentm@gmail.com> (http://trentm.com)
bin: 
  json:  ./lib/jsontool.js
  json3: ./lib/jsontool.js
main:            ./lib/jsontool.js
man:             ./man/man1/json.1
scripts: 
  test: make test
engines: 
  - node >=0.4.0
keywords: 
  - json
  - jsontool
  - filter
  - command
  - shell
dependencies: 
  prettyjson: = 0.5.0
devDependencies: 
  uglify-js: 1.1.x
  nodeunit:  0.7.x
  ansidiff:  1.0
```
