### PR TITLE
'json -n' option for validation

### DIFF
--- a/docs/json.1
+++ b/docs/json.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JSON" "1" "November 2012" "" "json tool manual"
+.TH "JSON" "1" "January 2013" "" "json tool manual"
 .
 .SH "NAME"
 \fBjson\fR \- (aka "jsontool") JSON love for your command line\.
@@ -348,7 +348,7 @@ Output the input object\'s keys\.
 \fBjson\fR can be restricting to just validating its input, i\.e\. processing and output of the input is skipped:
 .
 .TP
-\fB\-\-validate\fR
+\fB\-n\fR, \fB\-\-validate\fR
 Just validate the input, no processing or output of the JSON content\.
 .
 .P

--- a/docs/json.1.html
+++ b/docs/json.1.html
@@ -327,7 +327,7 @@ This can be overridden:</p>
 and output of the input is skipped:</p>
 
 <dl>
-<dt><code>--validate</code></dt><dd>Just validate the input, no processing or output of the JSON content.</dd>
+<dt><code>-n</code>, <code>--validate</code></dt><dd>Just validate the input, no processing or output of the JSON content.</dd>
 </dl>
 
 
@@ -752,7 +752,7 @@ npm as "jsontool" ("json" was already taken, boo).</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>November 2012</li>
+    <li class='tc'>January 2013</li>
     <li class='tr'>json(1)</li>
   </ol>
 

--- a/docs/json.1.ronn
+++ b/docs/json.1.ronn
@@ -243,7 +243,7 @@ An alternative to lookups is to output the keys of the input object:
 `json` can be restricting to just validating its input, i.e. processing
 and output of the input is skipped:
 
-  * `--validate`:
+  * `-n`, `--validate`:
     Just validate the input, no processing or output of the JSON content.
 
 

--- a/lib/jsontool.js
+++ b/lib/jsontool.js
@@ -215,8 +215,8 @@ function printHelp() {
   util.puts("                processed separately (use '-A' to override).");
   util.puts("");
   util.puts("  -k, --keys    Output the input object's keys.");
-  util.puts("  --validate    Just validate the input (no processing or output).");
-  util.puts("                Use with '-q' for silent validation (exit status).");
+  util.puts("  -n, --validate  Just validate the input (no processing or output).");
+  util.puts("                  Use with '-q' for silent validation (exit status).");
   util.puts("");
   util.puts("  -o, --output MODE   Specify an output mode. One of");
   util.puts("                  jsony (default): JSON with string quotes elided");
@@ -373,6 +373,7 @@ function parseArgv(argv) {
       case "-f":
         parsed.inputFiles.push(args.shift());
         break;
+      case "-n":
       case "--validate":
         parsed.validate = true;
         break;


### PR DESCRIPTION
I've added a -n option for validation.  This new option is intended to mirror the 'bash -n' option for checking a script's syntax.
