### PR TITLE
trivial: remove the shebang from lib/jsontool.js so that it is a plain-old javascript file*

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ See <http://trentm.com/json> for full docs and many examples.
    with no external dependencies). For example:
 
         cd ~/bin
-        curl -L https://github.com/trentm/json/raw/master/lib/jsontool.js > json
+        echo '#!/usr/bin/env node' > json
+        curl -L https://github.com/trentm/json/raw/master/lib/jsontool.js >> json
         chmod 755 json
 
 You should now have "json" on your PATH:

--- a/bin/json
+++ b/bin/json
@@ -1,1 +1,5 @@
-../lib/jsontool.js
+#!/usr/bin/env node
+
+jsontool = require("../lib/jsontool");
+
+jsontool.main(process.argv);

--- a/lib/jsontool.js
+++ b/lib/jsontool.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 //
 // json -- a 'json' command for massaging JSON on the command line
 //

--- a/test/100-continue/cmd
+++ b/test/100-continue/cmd
@@ -1,1 +1,1 @@
-cat input | ../../lib/jsontool.js
+cat input | ../../bin/json

--- a/test/argv/cmd
+++ b/test/argv/cmd
@@ -1,4 +1,4 @@
-JSON=../../lib/jsontool.js
+JSON=../../bin/json
 
 $JSON -h | grep -- --help
 

--- a/test/array-missing-keys/cmd
+++ b/test/array-missing-keys/cmd
@@ -1,4 +1,4 @@
-JSON=../../lib/jsontool.js
+JSON=../../bin/json
 echo '[{"a":1}, {"a":2, "b":3}]' | $JSON -a a
 echo ""
 echo '[{"a":1}, {"a":2, "b":3}]' | $JSON -a a b

--- a/test/array-processing/cmd
+++ b/test/array-processing/cmd
@@ -1,4 +1,4 @@
-JSON=../../lib/jsontool.js
+JSON=../../bin/json
 
 echo '{"name":"Trent","id":12,"email":"trent@example.com"}' | $JSON name email
 

--- a/test/bad-auto-arrayification/cmd
+++ b/test/bad-auto-arrayification/cmd
@@ -1,1 +1,1 @@
-cat invalid.json | ../../lib/jsontool.js
+cat invalid.json | ../../bin/json

--- a/test/basic/cmd
+++ b/test/basic/cmd
@@ -1,4 +1,4 @@
-JSON=../../lib/jsontool.js
+JSON=../../bin/json
 
 cat input | $JSON
 $JSON -f input

--- a/test/conditionals/cmd
+++ b/test/conditionals/cmd
@@ -1,5 +1,5 @@
-JSON="../../lib/jsontool.js"
-JSON0="../../lib/jsontool.js -o json-0"
+JSON="../../bin/json"
+JSON0="../../bin/json -o json-0"
 
 # Basic -c usage:
 # 1. Filter based on the check.

--- a/test/empty-lookup/cmd
+++ b/test/empty-lookup/cmd
@@ -1,1 +1,1 @@
-cat input | ../../lib/jsontool.js blah
+cat input | ../../bin/json blah

--- a/test/executable/cmd
+++ b/test/executable/cmd
@@ -1,5 +1,5 @@
-JSON="../../lib/jsontool.js"
-JSON0="../../lib/jsontool.js -o json-0"
+JSON="../../bin/json"
+JSON0="../../bin/json -o json-0"
 
 echo '{"foo": "bar"}' | $JSON0 -e 'this.foo="baz"'
 #    {"foo":"baz"}

--- a/test/fickle-stdout/cmd
+++ b/test/fickle-stdout/cmd
@@ -1,1 +1,1 @@
-cat input | ../../lib/jsontool.js | head -1
+cat input | ../../bin/json | head -1

--- a/test/flat-array-input/cmd
+++ b/test/flat-array-input/cmd
@@ -1,4 +1,4 @@
-JSON="node ../../lib/jsontool.js -q -o json-0 --group"
+JSON="node ../../bin/json -q -o json-0 --group"
 
 echo "# simple"
 cat objects.input | $JSON

--- a/test/hyphen/cmd
+++ b/test/hyphen/cmd
@@ -1,5 +1,5 @@
 # See <https://github.com/trentm/json/issues#issue/1>
 echo "# unadorned"
-cat input | ../../lib/jsontool.js platform-release
+cat input | ../../bin/json platform-release
 echo "# bracket notation"
-cat input | ../../lib/jsontool.js '["platform-release"]'
+cat input | ../../bin/json '["platform-release"]'

--- a/test/invalid-json/cmd
+++ b/test/invalid-json/cmd
@@ -1,2 +1,2 @@
 # See <https://github.com/trentm/json/issues#issue/6>
-cat input | ../../lib/jsontool.js foo
+cat input | ../../bin/json foo

--- a/test/json3/cmd
+++ b/test/json3/cmd
@@ -1,4 +1,4 @@
-JSON=../../lib/jsontool.js
+JSON=../../bin/json
 
 # Change from json2: '-j' means JSON output.
 echo '[{"name":"trent", "age":38}, {"name":"ewan", "age":4}]' | $JSON -j -a name   # json

--- a/test/keys/cmd
+++ b/test/keys/cmd
@@ -1,4 +1,4 @@
-JSON=../../lib/jsontool.js
+JSON=../../bin/json
 
 echo '{"name":"trent", "age":38}' | $JSON -k
 echo '{"name":"trent", "age":38}' | $JSON -k -a

--- a/test/lookups/cmd
+++ b/test/lookups/cmd
@@ -1,4 +1,4 @@
-JSON=../../lib/jsontool.js
+JSON=../../bin/json
 
 echo '{"name":"trent", "age":38}' | $JSON name
 echo '{"name":"trent", "age":38}' | $JSON name age

--- a/test/merge/cmd
+++ b/test/merge/cmd
@@ -1,4 +1,4 @@
-JSON=../../lib/jsontool.js
+JSON=../../bin/json
 
 echo '# basic'
 echo '{"foo":"bar"}{"one":"two"}' | $JSON --merge

--- a/test/multiargs/cmd
+++ b/test/multiargs/cmd
@@ -1,1 +1,1 @@
-cat input | ../../lib/jsontool.js one two
+cat input | ../../bin/json one two

--- a/test/period/cmd
+++ b/test/period/cmd
@@ -1,3 +1,3 @@
 # See <https://github.com/trentm/json/issues#issue/5>
 echo "# bracket notation"
-cat input | ../../lib/jsontool.js '["foo.bar"]'
+cat input | ../../bin/json '["foo.bar"]'

--- a/test/quiet/cmd
+++ b/test/quiet/cmd
@@ -1,7 +1,7 @@
 echo "# no args"
 # `cut` to avoid v8 version diffs in the SyntaxError message.
-cat input | ../../lib/jsontool.js 2>&1 | cut -c 1-45
+cat input | ../../bin/json 2>&1 | cut -c 1-45
 echo "# -q"
-cat input | ../../lib/jsontool.js -q 2>&1
+cat input | ../../bin/json -q 2>&1
 echo "# --quiet"
-cat input | ../../lib/jsontool.js --quiet 2>&1
+cat input | ../../bin/json --quiet 2>&1

--- a/test/stream-100-continue/cmd
+++ b/test/stream-100-continue/cmd
@@ -1,1 +1,1 @@
-cat input | ../../lib/jsontool.js -ga
+cat input | ../../bin/json -ga

--- a/test/stream-flat-array-input/cmd
+++ b/test/stream-flat-array-input/cmd
@@ -1,4 +1,4 @@
-JSON="node ../../lib/jsontool.js -q --group --array"
+JSON="node ../../bin/json -q --group --array"
 
 echo "# simple"
 cat objects.input | $JSON

--- a/test/stream/cmd
+++ b/test/stream/cmd
@@ -1,4 +1,4 @@
-JSON=../../lib/jsontool.js
+JSON=../../bin/json
 
 node ../docstream.js 3 | $JSON -ga >stream.log &
 sleep 2.5

--- a/test/syntax-error/cmd
+++ b/test/syntax-error/cmd
@@ -1,1 +1,1 @@
-cat input | ../../lib/jsontool.js
+cat input | ../../bin/json

--- a/test/undefined/cmd
+++ b/test/undefined/cmd
@@ -1,5 +1,5 @@
 echo "# foo key output"
-cat input | ../../lib/jsontool.js foo
+cat input | ../../bin/json foo
 
 echo "# undefined key output"
-cat input | ../../lib/jsontool.js nosuchkey
+cat input | ../../bin/json nosuchkey

--- a/test/utf8/cmd
+++ b/test/utf8/cmd
@@ -1,2 +1,2 @@
 # See <http://code.google.com/p/v8/issues/detail?id=855>
-cat input | ../../lib/jsontool.js
+cat input | ../../bin/json


### PR DESCRIPTION
Tests still pass and the 'download manually' instructions are also patched.

---
- the advantage for me is that jslint doesn't choke immediately on line zero;
