### PR TITLE
README: Add json2 to Alternatives list

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ focus.
 - JSONPath: <http://goessner.net/articles/JsonPath/>, <http://code.google.com/p/jsonpath/wiki/Javascript>
 - jsawk: <https://github.com/micha/jsawk>
 - jshon: <http://kmkeen.com/jshon/>
+- json2: <https://github.com/vi/json2>


### PR DESCRIPTION
Add my little project "json2" to the alternatives list.
It implements xml2/2xml approach to JSON.
