### PR TITLE
restore old -c/-e functionality regarding implict "this"

### DIFF
--- a/lib/json.js
+++ b/lib/json.js
@@ -1221,7 +1221,7 @@ function funcWithReturnFromSnippet(js) {
         if (js.substring(js.length - 1) === ';') {
             js = js.substring(0, js.length - 1);
         }
-        js = 'return (' + js + ')';
+        js = 'with (this) { return (' + js + '); }';
     }
     return (new Function(js));
 }
@@ -1280,7 +1280,8 @@ function main(argv) {
     var exeFuncs = [];
     if (!execVm) {
         for (i = 0; i < opts.exeSnippets.length; i++) {
-            exeFuncs[i] = new Function(opts.exeSnippets[i]);
+            exeFuncs[i] = new Function('with (this) {\n'
+                + opts.exeSnippets[i] + '\n}');
         }
     }
     var exeScripts = [];


### PR DESCRIPTION
needs some testing still, but it works

object

```
$ echo '{"green": "eggs"}' | ./lib/json.js -e 'green="ham"'
{
  "green": "ham"
}
```

array

```
$ echo '[{"name": "dave"}, {"name": "trent"}]' | ./lib/json.js -ac 'name === "dave"'
{
  "name": "dave"
}
```
