### PR TITLE
`json -ga` performance degradation on long lines. Fixes #112.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,18 @@
 # json Changelog
 
-## json 9.0.5 (not yet released)
+## json 9.0.6 (not yet released)
 
 (nothing yet)
 
+
+## json 9.0.5
+
+- [issue #112] Improve streaming (json -ga) performance for very long lines. For
+  example, using a 35 MB JSON object on one line gave a 50x speed improvement.
+  However, this is restricted to streaming of newline-separated JSON as opposed
+  to adjacent JSON objects not separated by newlines ({"a":1}{"a":2}). The
+  former case is expected to be much more common, and the latter may take a
+  slight performance hit from this change.
 
 ## json 9.0.4
 

--- a/lib/json.js
+++ b/lib/json.js
@@ -8,7 +8,7 @@
  * See <https://github.com/trentm/json> and <https://trentm.com/json/>
  */
 
-var VERSION = '9.0.5';
+var VERSION = '9.0.6';
 
 var p = console.warn;
 var util = require('util');
@@ -627,7 +627,11 @@ function chunkEmitter(opts) {
                     chunks.push(chunk);
                     return;
                 }
-                leftover = emitChunks(s, emitter);
+                if (chunk.lastIndexOf('\n') >= 0) {
+                    leftover = emitChunks(s, emitter);
+                } else {
+                    leftover = s;
+                }
             }
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "json",
   "description": "a 'json' command for massaging and processing JSON on the command line",
-  "version": "9.0.5",
+  "version": "9.0.6",
   "repository": {
     "type": "git",
     "url": "git://github.com/trentm/json.git"


### PR DESCRIPTION
This works (50x speed-up of the large-line test), all tests pass (well, the in-place test failed, but it did that before my changes).
```
$ time json -ga -f bigline.json req_id
25acc48b-961e-476d-87e9-25ced74a2aa6

real	0m0.446s
user	0m0.325s
sys	0m0.124s
```

I'd like you to sanity check that the quick '\n' doesn't have any side affects.

Also, I didn't notice any performance difference when testing this patch on a large regular JSON file (2,000,000 line file, around 80MB). Timings seemed around the same with/without the patch.
