### PR TITLE
Fix flag in --in-place modification example

### DIFF
--- a/lib/json.js
+++ b/lib/json.js
@@ -190,7 +190,7 @@ function printHelp() {
     w('In-place editing:');
     w('  Use "-I, --in-place" to edit a file in place:');
     w('     $ json -I -f config.json  # reformat');
-    w('     $ json -I -f config.json -c \'this.logLevel="debug"\' # add field');
+    w('     $ json -I -f config.json -e \'this.logLevel="debug"\' # add field');
     w('');
     w('Pretty-printing:');
     w('  Output is "jsony" by default: 2-space indented JSON, except a');


### PR DESCRIPTION
This tiny PR replaces `-c` with `-e` in the usage example for in-place editing shown with `json -h`.

The current example doesn't actually add a property in place, since `-c` denotes filtering, rather than execution.