### PR TITLE
Add example of adding/updating a field that contains dots/periods

### DIFF
--- a/docs/json.1.html
+++ b/docs/json.1.html
@@ -538,6 +538,16 @@ $ cat config.json
   "hostname": "127.0.0.1",
   "port": 8080
 }
+
+# add/update field that contains periods
+$ json -I -f config.json -e 'this["field.with.periods"]="update"'
+json: updated "config.json" in-place
+$ cat config.json
+{
+  "hostname": "127.0.0.1",
+  "port": 8080,
+  "field.with.periods": "update"
+}
 </code></pre>
 
 <p>Some limitations. Only one file at a time:</p>

--- a/docs/json.1.ronn
+++ b/docs/json.1.ronn
@@ -425,6 +425,16 @@ You can edit a file in place with `-I` and `-f FILE`:
       "port": 8080
     }
 
+    # add/update field that contains periods
+    $ json -I -f config.json -e 'this["field.with.periods"]="update"'
+    json: updated "config.json" in-place
+    $ cat config.json
+    {
+      "hostname": "127.0.0.1",
+      "port": 8080,
+      "field.with.periods": "update"
+    }
+
 Some limitations. Only one file at a time:
 
     $ json -I -f foo.json -f bar.json


### PR DESCRIPTION
JSON assumes periods indicate an inner context. That's not always true. See issue [159](https://github.com/trentm/json/issues/159).

This adds an example to the docs based on the suggested solution.

---

I specifically found this answer helpful when updating VSCode settings, [here](https://github.com/sej3506/saras-adventures-in-learning/blob/d8ddb2cbf9161c1ecf21a524919d4d0b074a1f84/bin/solargraph_setup.sh#L88).