### PR TITLE
chore: add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "git://github.com/trentm/json.git"
   },
+  "license": "MIT",
   "author": "Trent Mick <trentm@gmail.com> (https://trentm.com)",
   "main": "./lib/json.js",
   "files": [


### PR DESCRIPTION
Hello!

This is a simple change specifying your package's license in package.json according to the license info you provide in readme. This makes it easier to automate license checks.